### PR TITLE
chore: Add PUT endpoint for updating posts

### DIFF
--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
@@ -25,6 +25,21 @@ public class PostController {
         return repository.findAll().stream().collect(Collectors.toList());
     }
 
+    @PutMapping("/posts/{id}")
+    public Post putPosts(@PathVariable("id") Long id, @RequestBody Post newPost) {
+        log.info("{}: received a PUT request", deploymentType);
+        return repository.findById(id)
+            .map(post -> {
+                post.setTitle(newPost.getTitle());
+                post.setContent(newPost.getContent());
+                return repository.save(post);
+            })
+            .orElseGet(() -> {
+                newPost.setId(id);
+                return repository.save(newPost);
+            });
+    }
+
     @PostMapping("/posts")
     public Post post(@RequestBody Post post, HttpServletResponse resp) {
         log.info("{}: recieved a POST request", deploymentType);


### PR DESCRIPTION
This pull request includes a significant update to the `PostController.java` file. The change introduces a new endpoint that allows for updating existing posts or creating a new post if the specified post does not exist.

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java`](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R28-R42): Added a new `@PutMapping` annotated method `putPosts()`. This method receives a `PUT` request with a post `id` and a `newPost` object. If the `id` exists, it updates the corresponding post's title and content with the information from `newPost` and saves it to the repository. If the `id` does not exist, it sets the `id` of `newPost` and saves `newPost` to the repository.