### PR TITLE
feat: add new endpoints and test

### DIFF
--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
@@ -1,0 +1,27 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class AuthorController {
+
+    @Autowired
+    private AuthorService authorService;
+
+    @GetMapping("/authors")
+    public List<Author> getAuthors() {
+        return authorService.getAuthors();
+    }
+
+    @GetMapping("/authors/{id}")
+    public Author getAuthorById(@PathVariable Long id) {
+        return authorService.getAuthorById(id);
+    }
+
+    // Add more methods as needed
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
@@ -92,4 +92,16 @@ public class Post {
         String pattern = "\\b(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]";
         return postLink.matches(pattern);
     }
+
+    private String dateUpdated;
+
+    public void setDateUpdated(Date dateAsDate) {
+        DateFormat dateFormat = new SimpleDateFormat(dateFormat());
+        this.dateUpdated = dateFormat.format(dateAsDate);
+    }
+
+    public String getDateUpdated() {
+        return dateUpdated;
+    }
 }
+

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
@@ -1,0 +1,48 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class AuthorControllerTest {
+
+    @Autowired
+    private AuthorController authorController;
+
+    @MockBean
+    private AuthorService authorService;
+
+    @Test
+    public void testGetAuthors() {
+        Author author1 = new Author("Author1", "Bio1");
+        Author author2 = new Author("Author2", "Bio2");
+        List<Author> authors = Arrays.asList(author1, author2);
+
+        Mockito.when(authorService.getAuthors()).thenReturn(authors);
+
+        List<Author> result = authorController.getAuthors();
+
+        assertEquals(authors, result);
+    }
+
+    @Test
+    public void testGetAuthorById() {
+        Author author = new Author("Author1", "Bio1");
+
+        Mockito.when(authorService.getAuthorById(1L)).thenReturn(author);
+
+        Author result = authorController.getAuthorById(1L);
+
+        assertEquals(author, result);
+    }
+
+    // Add more tests as needed
+}

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
@@ -2,11 +2,16 @@ package com.liatrio.dojo.devopsknowledgeshareapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.text.SimpleDateFormat;
+import java.text.DateFormat;
 
 @ExtendWith(SpringExtension.class)
 public class PostTest {
@@ -16,7 +21,6 @@ public class PostTest {
     String title = "devops";
     String link = "https://devops.com/blog/post-1";
     String imageUrl = "https://devops.com/images/image1.png";
-
 
     @Test
     public void getIdTest() throws Exception {
@@ -105,5 +109,16 @@ public class PostTest {
         hc.setImageUrl(imageUrl);
         String test = hc.getImageUrl();
         assertEquals(imageUrl, test);
+    }
+
+    @Test
+    public void setDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new Date();
+        hc.setDateUpdated(date);
+        String test = hc.getDateUpdated();
+        DateFormat dateFormat = new SimpleDateFormat(hc.dateFormat());
+        String expected = dateFormat.format(date);
+        assertEquals(expected, test);
     }
 }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the functionality of the `AuthorController` and `Post` classes, and adding corresponding test cases in `AuthorControllerTest` and `PostTest` classes. The most significant changes include the creation of `AuthorController` and `AuthorControllerTest` classes, addition of a `dateUpdated` field in `Post` class, and the corresponding test case in `PostTest`.

Here are the key changes grouped by theme:

**New Controller and Test Classes:**

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java`](diffhunk://#diff-7b1e726b8f5f6af5c93411a1fec2a857572ca4449068bbe74b5ca6b9395445a8R1-R27): Created a new `AuthorController` class with two methods `getAuthors()` and `getAuthorById(Long id)`. This class handles HTTP requests related to authors.
* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java`](diffhunk://#diff-5f2a7f6a4894387c89a4b31085305c1585e4733524b1b531ef4fb4c29c5df929R1-R48): Created a new `AuthorControllerTest` class to test the methods in `AuthorController`. It includes two test methods `testGetAuthors()` and `testGetAuthorById()`.

**Enhancements to Post Class and Test Case:**

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java`](diffhunk://#diff-bed6865f4a0cb824d20fcebc0d79e950632b4dec430bac7e7152e3b682630642R95-R107): Added a new `dateUpdated` field to the `Post` class along with its getter and setter methods. The `setDateUpdated(Date dateAsDate)` method formats the date to a string.
* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java`](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR113-R123): Added a new test case `setDateUpdatedTest()` to test the newly added `setDateUpdated` and `getDateUpdated` methods in the `Post` class.