### PR TITLE
feat: Add dateUpdated field to Post model and update PostController

### DIFF
--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
@@ -25,6 +25,16 @@ public class Post {
     private @NonNull String datePosted;
     private @NonNull String imageUrl;
     private @NonNull Date dateAsDate;
+    private String dateUpdated;
+
+    public void setDateUpdated(Date dateAsDate) {
+        DateFormat dateFormat = new SimpleDateFormat(dateFormat());
+        this.dateUpdated = dateFormat.format(dateAsDate);
+    }
+
+    public String getDateUpdated() {
+        return dateUpdated;
+    }
 
     public Post() {
         this.dateAsDate = Calendar.getInstance().getTime();

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
@@ -31,6 +31,20 @@ public class PostController {
         return repository.save(post);
     }
 
+    @PutMapping("/posts/{id}")
+    public Post putPost(@PathVariable("id") String id, @RequestBody Post updatedPost) throws Exception {
+        log.info("{}: received a PUT request", deploymentType);
+        Post existingPost = repository.findById(Long.parseLong(id)).orElse(null);
+        if (existingPost != null) {
+            existingPost.setFirstName(updatedPost.getFirstName());
+            existingPost.setTitle(updatedPost.getTitle());
+            existingPost.setLink(updatedPost.getLink());
+            return repository.save(existingPost);
+        } else {
+            throw new IllegalArgumentException("Post not found with id: " + id);
+        }
+    }
+
     @DeleteMapping("/posts/{id}")
     public void deletePost(@PathVariable("id") String id) {
         log.info("{}: recieved a DELETE request", deploymentType);

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java
@@ -1,5 +1,7 @@
 package com.liatrio.dojo.devopsknowledgeshareapi;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
@@ -7,4 +9,7 @@ import org.springframework.stereotype.Repository;
 @RepositoryRestResource
 @Repository
 interface PostRepository extends JpaRepository<Post, Long> {
+  List<Post> findByTitle(String title);
+  List<Post> findByFirstName(String firstName);
+  List<Post> findByLink(String link);
 }

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
@@ -1,12 +1,18 @@
 package com.liatrio.dojo.devopsknowledgeshareapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.text.DateFormat; // Import the DateFormat class
+import java.text.SimpleDateFormat;
 
 @ExtendWith(SpringExtension.class)
 public class PostTest {
@@ -105,5 +111,46 @@ public class PostTest {
         hc.setImageUrl(imageUrl);
         String test = hc.getImageUrl();
         assertEquals(imageUrl, test);
+    }
+
+    @Test
+    public void setDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new Date();
+        hc.setDateUpdated(date);
+        String test = hc.getDateUpdated();
+        DateFormat dateFormat = new SimpleDateFormat(hc.dateFormat());
+        String expected = dateFormat.format(date);
+        assertEquals(expected, test);
+    }
+
+    @Test
+    public void getDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new Date();
+        hc.setDateUpdated(date);
+        String test = hc.getDateUpdated();
+        DateFormat dateFormat = new SimpleDateFormat(hc.dateFormat());
+        String expected = dateFormat.format(date);
+        assertEquals(expected, test);
+    }
+
+    @Test
+    public void validatePostLinkTest() {
+        Post hc = new Post();
+        String validLink = "https://example.com";
+        boolean validResult = hc.validatePostLink(validLink);
+        assertTrue(validResult);
+
+        String invalidLink = "example.com";
+        boolean invalidResult = hc.validatePostLink(invalidLink);
+        assertFalse(invalidResult);
+    }
+
+    @Test
+    public void dateFormatTest() {
+        Post hc = new Post();
+        String test = hc.dateFormat();
+        assertEquals("yyyy-MM-dd", test);
     }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `Post` class, `PostController` class, `PostRepository` interface, and `PostTest` class in the `com.liatrio.dojo.devopsknowledgeshareapi` package. The most important changes include the addition of a `dateUpdated` field in the `Post` class, a new `PUT` method in the `PostController` class, new search methods in the `PostRepository` interface, and new test methods in the `PostTest` class.

Changes to the `Post` class:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java`](diffhunk://#diff-bed6865f4a0cb824d20fcebc0d79e950632b4dec430bac7e7152e3b682630642R28-R37): Added a new `dateUpdated` field along with its getter and setter methods. The setter method formats the date into a string using a specific date format.

Changes to the `PostController` class:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java`](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R34-R47): Added a new `PUT` method that updates an existing post with new data. This method first finds the existing post by its id, then updates its `firstName`, `title`, and `link` fields with the new data, and finally saves the updated post to the repository.

Changes to the `PostRepository` interface:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java`](diffhunk://#diff-cca0001c4a692ad60f486f2f8554dd59e7e9fb0960a42cc5d0c00918fe6654edR3-R14): Added new search methods to find posts by `title`, `firstName`, and `link`.

Changes to the `PostTest` class:

* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java`](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR4-R15): Added new test methods to validate the `setDateUpdated` and `getDateUpdated` methods of the `Post` class, validate a post's link, and test the date format used in the `Post` class. [[1]](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR4-R15) [[2]](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR115-R155)