### PR TITLE
feat: Add dateUpdated field to Post model and update PostController

### DIFF
--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
@@ -1,0 +1,20 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.liatrio.dojo.devopsknowledgeshareapi.AuthorService;
+
+
+@RestController
+public class AuthorController {
+
+    @Autowired
+    private AuthorService authorService;
+
+    @GetMapping("/authors")
+    public Object getAuthors() {
+        // TODO: Replace Object with your Author class
+        return authorService.getAuthors();
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorService.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorService.java
@@ -1,0 +1,15 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class AuthorService {
+
+    public List<Object> getAuthors() {
+        // TODO: Replace Object with your Author class
+        // TODO: Implement the logic to fetch and return the list of authors
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
@@ -25,6 +25,16 @@ public class Post {
     private @NonNull String datePosted;
     private @NonNull String imageUrl;
     private @NonNull Date dateAsDate;
+    private String dateUpdated;
+
+    public void setDateUpdated(Date dateAsDate) {
+        DateFormat dateFormat = new SimpleDateFormat(dateFormat());
+        this.dateUpdated = dateFormat.format(dateAsDate);
+    }
+
+    public String getDateUpdated() {
+        return dateUpdated;
+    }
 
     public Post() {
         this.dateAsDate = Calendar.getInstance().getTime();

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
@@ -1,5 +1,7 @@
 package com.liatrio.dojo.devopsknowledgeshareapi;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import lombok.extern.slf4j.Slf4j;
@@ -25,12 +27,45 @@ public class PostController {
         return repository.findAll().stream().collect(Collectors.toList());
     }
 
+    @GetMapping("/posts/title/{title}")
+    public Collection<Post> getPostsByTitle(@PathVariable String title) {
+        return repository.findByTitle(title);
+    }
+
+    @GetMapping("/posts/firstName/{firstName}")
+    public Collection<Post> getPostsByFirstName(@PathVariable String firstName) {
+        return repository.findByFirstName(firstName);
+    }
+
+    @GetMapping("/posts/link/{link}")
+    public Collection<Post> getPostsByLink(@PathVariable String link) {
+        return repository.findByLink(link);
+    }
+
     @PostMapping("/posts")
     public Post post(@RequestBody Post post, HttpServletResponse resp) {
         log.info("{}: recieved a POST request", deploymentType);
         return repository.save(post);
     }
 
+    @PutMapping("/posts/{id}")
+    public ResponseEntity<Post> putPost(@PathVariable("id") Long id, @RequestBody Post post) {
+        log.info("{}: received a PUT request", deploymentType);
+        return repository.findById(id)
+                .map(existingPost -> {
+                    existingPost.setTitle(post.getTitle());
+                    existingPost.setFirstName(post.getFirstName());
+                    try {
+                        existingPost.setLink(post.getLink());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        // handle exception
+                    }
+                    return new ResponseEntity<>(repository.save(existingPost), HttpStatus.OK);
+                })
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+    
     @DeleteMapping("/posts/{id}")
     public void deletePost(@PathVariable("id") String id) {
         log.info("{}: recieved a DELETE request", deploymentType);

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java
@@ -3,8 +3,14 @@ package com.liatrio.dojo.devopsknowledgeshareapi;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.liatrio.dojo.devopsknowledgeshareapi.Post;
+import java.util.List;
 
 @RepositoryRestResource
 @Repository
 interface PostRepository extends JpaRepository<Post, Long> {
+  List<Post> findByTitle(String title);
+  List<Post> findByFirstName(String firstName);
+  List<Post> findByLink(String link);
 }

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
@@ -1,0 +1,36 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.when;
+
+import com.liatrio.dojo.devopsknowledgeshareapi.AuthorService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthorService authorService;
+
+    @Test
+    public void getAuthorsTest() throws Exception {
+        when(authorService.getAuthors()).thenReturn(new ArrayList<>());
+
+        mockMvc.perform(get("/authors"))
+            .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
@@ -2,6 +2,11 @@ package com.liatrio.dojo.devopsknowledgeshareapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
@@ -105,5 +110,27 @@ public class PostTest {
         hc.setImageUrl(imageUrl);
         String test = hc.getImageUrl();
         assertEquals(imageUrl, test);
+    }
+
+    @Test
+    public void setDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse("2022-01-01");
+        hc.setDateUpdated(date);
+        String test = hc.getDateUpdated();
+        DateFormat dateFormat = new SimpleDateFormat(hc.dateFormat());
+        String expected = dateFormat.format(date);
+        assertEquals(expected, test);
+    }
+
+    @Test
+    public void getDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse("2022-01-01");
+        hc.setDateUpdated(date);
+        String test = hc.getDateUpdated();
+        DateFormat dateFormat = new SimpleDateFormat(hc.dateFormat());
+        String expected = dateFormat.format(date);
+        assertEquals(expected, test);
     }
 }


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `devopsknowledgeshareapi` project. The most significant changes include the addition of `AuthorController` and `AuthorService` classes, new search capabilities in `PostController`, an update field in the `Post` class, and corresponding updates to the test classes.

New Classes:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java`](diffhunk://#diff-7b1e726b8f5f6af5c93411a1fec2a857572ca4449068bbe74b5ca6b9395445a8R1-R20): A new `AuthorController` class was added. It uses the `AuthorService` to handle requests to the `/authors` endpoint.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorService.java`](diffhunk://#diff-2da92890250bd777848534cfeb81a32d91d012d35696f64fa57942047d06c51eR1-R15): A new `AuthorService` class was added. It currently returns an empty list of authors.

Updates to Existing Classes:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java`](diffhunk://#diff-bed6865f4a0cb824d20fcebc0d79e950632b4dec430bac7e7152e3b682630642R28-R37): The `Post` class was updated to include a `dateUpdated` field with corresponding getter and setter methods.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java`](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R3-R4): The `PostController` class was updated to include new search capabilities. It can now handle requests to search posts by title, first name, and link. Additionally, a PUT request handler was added to update existing posts. [[1]](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R3-R4) [[2]](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R30-R68)
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java`](diffhunk://#diff-cca0001c4a692ad60f486f2f8554dd59e7e9fb0960a42cc5d0c00918fe6654edR6-R15): The `PostRepository` interface was updated to include new methods for finding posts by title, first name, and link.

Test Updates:

* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java`](diffhunk://#diff-5f2a7f6a4894387c89a4b31085305c1585e4733524b1b531ef4fb4c29c5df929R1-R36): A new test class for `AuthorController` was added. It currently includes a single test for the `getAuthors` method.
* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java`](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR5-R9): The `PostTest` class was updated to include new tests for the `dateUpdated` field in the `Post` class. [[1]](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR5-R9) [[2]](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR114-R135)