### PR TITLE
Copilot feature rld

### DIFF
--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthController.java
@@ -1,0 +1,14 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @GetMapping("/authors")
+    public ResponseEntity<String> getAuthors() {
+        return ResponseEntity.ok("Authors endpoint");
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
@@ -88,6 +88,17 @@ public class Post {
         this.imageUrl = imageUrl;
     }
 
+    private String dateUpdated;
+
+    public void setDateUpdated(Date dateAsDate) {
+        DateFormat dateFormat = new SimpleDateFormat(dateFormat());
+        this.dateUpdated = dateFormat.format(dateAsDate);
+    }
+
+    public String getDateUpdated() {
+        return dateUpdated;
+    }
+
     public boolean validatePostLink(String postLink) {
         String pattern = "\\b(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]";
         return postLink.matches(pattern);

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
@@ -1,5 +1,6 @@
 package com.liatrio.dojo.devopsknowledgeshareapi;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,25 @@ public class PostController {
     public Post post(@RequestBody Post post, HttpServletResponse resp) {
         log.info("{}: recieved a POST request", deploymentType);
         return repository.save(post);
+    }
+
+    @PutMapping("/posts/{id}")
+    public Post updatePost(@PathVariable Long id, @RequestBody Post newPost) {
+        return repository.findById(id)
+            .map(post -> {
+                post.setTitle(newPost.getTitle());
+                post.setFirstName(newPost.getFirstName());
+                try {
+                    post.setLink(newPost.getLink());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                return repository.save(post);
+            })
+            .orElseGet(() -> {
+                newPost.setId(id);
+                return repository.save(newPost);
+            });
     }
 
     @DeleteMapping("/posts/{id}")

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthControllerTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthControllerTest.java
@@ -1,0 +1,24 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testGetAuthors() throws Exception {
+        mockMvc.perform(get("/authors"))
+               .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
@@ -2,11 +2,16 @@ package com.liatrio.dojo.devopsknowledgeshareapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 @ExtendWith(SpringExtension.class)
 public class PostTest {
@@ -106,4 +111,26 @@ public class PostTest {
         String test = hc.getImageUrl();
         assertEquals(imageUrl, test);
     }
+
+    @Test
+    public void setDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new Date();
+        hc.setDateUpdated(date);
+        DateFormat dateFormat = new SimpleDateFormat(hc.dateFormat());
+        String expected = dateFormat.format(date);
+        String actual = hc.getDateUpdated();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new Date();
+        hc.setDateUpdated(date);
+        DateFormat dateFormat = new SimpleDateFormat(hc.dateFormat());
+        String expected = dateFormat.format(date);
+        String actual = hc.getDateUpdated();
+        assertEquals(expected, actual);
+}
 }


### PR DESCRIPTION
Fixes #
This pull request introduces several changes to the `devopsknowledgeshareapi` package, mainly focusing on the addition of new features and tests. The most significant changes include the creation of a new `AuthController` class, the addition of a `dateUpdated` field in the `Post` class, and the introduction of new tests in `AuthControllerTest` and `PostTest`. 

New features:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthController.java`](diffhunk://#diff-9007100531a5b4205814b3beafb9aaeb0af831f4d428fb9af46c6e4613db1a17R1-R14): A new `AuthController` class was created, including a `getAuthors` method that returns a `ResponseEntity` object with a string message.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java`](diffhunk://#diff-bed6865f4a0cb824d20fcebc0d79e950632b4dec430bac7e7152e3b682630642R91-R101): A `dateUpdated` field was added to the `Post` class, along with corresponding `setDateUpdated` and `getDateUpdated` methods.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java`](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R35-R53): A `updatePost` method was added to the `PostController` class, allowing updates to existing posts.

Test additions:

* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthControllerTest.java`](diffhunk://#diff-13527cc04f2e8f48d04895e4cc7baa4d6d3e9c346dacee26b7da5485c1bbacc1R1-R24): A new `AuthControllerTest` class was created, including a `testGetAuthors` method to test the `getAuthors` method in `AuthController`.
* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java`](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR114-R135): Two new tests were added to the `PostTest` class to test the `setDateUpdated` and `getDateUpdated` methods in `Post`.

Minor changes:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java`](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R3): The `ResponseEntity` import was added.
* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java`](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR5-R14): The `Date`, `DateFormat`, and `SimpleDateFormat` imports were added.
