### PR TITLE
feat: Add Author class and AuthorController

### DIFF
--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Author.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Author.java
@@ -1,0 +1,23 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+public class Author {
+    private String firstName;
+    private String lastName;
+
+    // Getters and setters
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
@@ -1,0 +1,21 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class AuthorController {
+
+    @Autowired
+    private AuthorService authorService;
+
+    @GetMapping("/authors")
+    public ResponseEntity<List<Author>> getAuthors() {
+        List<Author> authors = authorService.getAllAuthors();
+        return ResponseEntity.ok(authors);
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorService.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorService.java
@@ -1,0 +1,15 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.ArrayList;
+
+@Service
+public class AuthorService {
+
+    public List<Author> getAllAuthors() {
+        // This is a stub. Replace with actual implementation.
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
@@ -63,7 +63,7 @@ public class Post {
         if (this.validatePostLink(link)) {
             this.link = link;
         } else {
-            throw new Exception("Invalid link format ");
+            throw new Exception("Invalid link format: " + link);
         }
     }
 

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
@@ -1,0 +1,44 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AuthorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Mock
+    private AuthorService authorService;
+
+    @InjectMocks
+    private AuthorController authorController;
+
+    @BeforeAll
+    public void setup() {
+        this.mockMvc = standaloneSetup(authorController).build();
+    }
+
+    @Test
+    public void testGetAuthors() throws Exception {
+        mockMvc.perform(get("/authors"))
+               .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION

This pull request primarily introduces a new feature to the `devopsknowledgeshareapi` application: the ability to handle `Author` objects. This includes the creation of the `Author` class, an `AuthorService` to manage `Author` objects, and an `AuthorController` to handle HTTP requests related to `Author` objects. Additionally, a unit test for the `AuthorController` was added, and a small modification was made to the `Post` class to improve error messaging.

New feature - Handling of `Author` objects:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Author.java`](diffhunk://#diff-63ee1a840244be28da65e8b4f7a537d79305e4f9a8972ae8af277ddb9cabcbf0R1-R23): A new `Author` class was introduced, which includes `firstName` and `lastName` as attributes.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorService.java`](diffhunk://#diff-2da92890250bd777848534cfeb81a32d91d012d35696f64fa57942047d06c51eR1-R15): An `AuthorService` class was added, which currently includes a stub for a method to get all authors.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java`](diffhunk://#diff-7b1e726b8f5f6af5c93411a1fec2a857572ca4449068bbe74b5ca6b9395445a8R1-R21): An `AuthorController` class was introduced, which includes a `getAuthors` method to handle HTTP GET requests at the `/authors` endpoint.

Testing:

* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java`](diffhunk://#diff-5f2a7f6a4894387c89a4b31085305c1585e4733524b1b531ef4fb4c29c5df929R1-R44): A unit test for the `AuthorController` was added, which tests the HTTP GET request at the `/authors` endpoint.

Improvement to existing code:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java`](diffhunk://#diff-bed6865f4a0cb824d20fcebc0d79e950632b4dec430bac7e7152e3b682630642L66-R66): The error message in the `setLink` method was improved to include the invalid link.

