### PR TITLE
feat: add controller endpoint functionality.

### DIFF
--- a/src/functionalTest/java/com/liatrio/dojo/devopsknowledgeshareapi/InfoControllerTest.java
+++ b/src/functionalTest/java/com/liatrio/dojo/devopsknowledgeshareapi/InfoControllerTest.java
@@ -1,0 +1,49 @@
+// package com.liatrio.dojo.devopsknowledgeshareapi;
+
+// import io.restassured.path.json.JsonPath;
+// import io.restassured.response.Response;
+// import org.junit.jupiter.api.*;
+// import io.restassured.specification.RequestSpecification;
+// import io.restassured.builder.RequestSpecBuilder;
+// import io.restassured.filter.log.RequestLoggingFilter;
+// import io.restassured.filter.log.ResponseLoggingFilter;
+// import io.restassured.filter.log.ErrorLoggingFilter;
+// import org.springframework.boot.test.context.SpringBootTest;
+
+// import static io.restassured.RestAssured.given;
+// import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// @SpringBootTest
+// @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+// public class InfoControllerTest {
+
+//     private static RequestSpecification request;
+
+//     @BeforeAll
+//     public static void setup() {
+//         request = new RequestSpecBuilder()
+//                 .setBaseUri("http://localhost:8080")
+//                 .addFilter(new RequestLoggingFilter())
+//                 .addFilter(new ResponseLoggingFilter())
+//                 .addFilter(new ErrorLoggingFilter())
+//                 .build();
+//     }
+
+//     /**
+//      * Scenario: User visits the /info URL of the service
+//      * Given the user is not logged in
+//      * When the user visits the /info page
+//      * Then the user should see the phrase "Welcome to the API version 1.0"
+//      * And they should not see an error message
+//      */
+//     @Test
+//     @Order(1)
+//     public void userVisitsInfoPage() {
+//         Response response = given().spec(request).get("/info");
+//         assertEquals(200, response.getStatusCode());
+
+//         JsonPath jsonPath = new JsonPath(response.asString());
+//         String message = jsonPath.getString("message");
+//         assertEquals("Welcome to the API version 1.0", message);
+//     }
+// }

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Author.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Author.java
@@ -1,0 +1,28 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+public class Author {
+    private Long id;
+    private String name;
+
+    public Author(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java
@@ -1,0 +1,17 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+import java.util.Arrays;
+
+@RestController
+public class AuthorController {
+
+    @GetMapping("/authors")
+    public List<Author> getAuthors() {
+        Author author1 = new Author(1L, "Author One");
+        Author author2 = new Author(2L, "Author Two");
+        return Arrays.asList(author1, author2);
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/InfoController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/InfoController.java
@@ -1,0 +1,18 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+public class InfoController {
+
+    @GetMapping(value = "/info", produces = "application/json")
+    public Map<String, String> getInfo() {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "Welcome to the API version 1.0");
+        return response;
+    }
+}

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
@@ -26,6 +26,17 @@ public class Post {
     private @NonNull String imageUrl;
     private @NonNull Date dateAsDate;
 
+    private String dateUpdated;
+
+    public void setDateUpdated(Date dateAsDate) {
+        DateFormat dateFormat = new SimpleDateFormat(dateFormat());
+        this.dateUpdated = dateFormat.format(dateAsDate);
+    }
+
+    public String getDateUpdated() {
+        return dateUpdated;
+    }
+
     public Post() {
         this.dateAsDate = Calendar.getInstance().getTime();
         setDatePosted(dateAsDate);

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
@@ -7,6 +7,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import java.util.List;
+
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @Slf4j
@@ -25,10 +27,50 @@ public class PostController {
         return repository.findAll().stream().collect(Collectors.toList());
     }
 
+    @GetMapping("/posts/title")
+    public List<Post> getPostsByTitle(@RequestParam String title) {
+        log.info("{}: received a GET request for posts by title", deploymentType);
+        return repository.findByTitle(title);
+    }
+
+    @GetMapping("/posts/firstname")
+    public List<Post> getPostsByFirstName(@RequestParam String firstName) {
+        log.info("{}: received a GET request for posts by first name", deploymentType);
+        return repository.findByFirstName(firstName);
+    }
+
+    @GetMapping("/posts/link")
+    public List<Post> getPostsByLink(@RequestParam String link) {
+        log.info("{}: received a GET request for posts by link", deploymentType);
+        return repository.findByLink(link);
+    }
+
     @PostMapping("/posts")
     public Post post(@RequestBody Post post, HttpServletResponse resp) {
         log.info("{}: recieved a POST request", deploymentType);
         return repository.save(post);
+    }
+
+    @PutMapping("/posts/{id}")
+    public Post putPost(@PathVariable("id") Long id, @RequestBody Post updatedPost) throws Exception {
+        log.info("{}: recieved a PUT request", deploymentType);
+        return repository.findById(id)
+                .map(post -> {
+                    post.setFirstName(updatedPost.getFirstName());
+                    post.setTitle(updatedPost.getTitle());
+                    try {
+                        post.setLink(updatedPost.getLink());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    post.setDatePosted(updatedPost.getDateAsDate());
+                    post.setImageUrl(updatedPost.getImageUrl());
+                    return repository.save(post);
+                })
+                .orElseGet(() -> {
+                    updatedPost.setId(id);
+                    return repository.save(updatedPost);
+                });
     }
 
     @DeleteMapping("/posts/{id}")

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java
@@ -4,7 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @RepositoryRestResource
 @Repository
 interface PostRepository extends JpaRepository<Post, Long> {
+  List<Post> findByTitle(String title);
+  List<Post> findByFirstName(String firstName);
+  List<Post> findByLink(String link);
 }

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java
@@ -1,0 +1,40 @@
+package com.liatrio.dojo.devopsknowledgeshareapi;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc()
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AuthorControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @InjectMocks
+    AuthorController mockAuthorController;
+
+    @BeforeAll
+    public void setup() throws Exception {
+        this.mockMvc = standaloneSetup(mockAuthorController).build();
+    }
+
+    @Test
+    public void getAuthorsResponse() throws Exception {
+        this.mockMvc.perform(get("/authors"))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 @ExtendWith(SpringExtension.class)
 public class PostTest {
@@ -105,5 +107,23 @@ public class PostTest {
         hc.setImageUrl(imageUrl);
         String test = hc.getImageUrl();
         assertEquals(imageUrl, test);
+    }
+
+    @Test
+    public void setDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse("2023-10-01");
+        hc.setDateUpdated(date);
+        String expectedDate = new SimpleDateFormat(hc.dateFormat()).format(date);
+        assertEquals(expectedDate, hc.getDateUpdated());
+    }
+
+    @Test
+    public void getDateUpdatedTest() throws Exception {
+        Post hc = new Post();
+        Date date = new SimpleDateFormat("yyyy-MM-dd").parse("2023-10-01");
+        hc.setDateUpdated(date);
+        String expectedDate = new SimpleDateFormat(hc.dateFormat()).format(date);
+        assertEquals(expectedDate, hc.getDateUpdated());
     }
 }


### PR DESCRIPTION
This pull request introduces several new features and enhancements to the `devopsknowledgeshareapi` project, including new endpoints, a new entity, and corresponding tests. The most important changes include the addition of the `Author` entity and its controller, enhancements to the `Post` entity and its controller, and new test cases for the controllers and entities.

### New Features:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Author.java`](diffhunk://#diff-63ee1a840244be28da65e8b4f7a537d79305e4f9a8972ae8af277ddb9cabcbf0R1-R28): Added the `Author` entity with `id` and `name` fields, along with their getters and setters.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorController.java`](diffhunk://#diff-7b1e726b8f5f6af5c93411a1fec2a857572ca4449068bbe74b5ca6b9395445a8R1-R17): Created `AuthorController` with a `/authors` endpoint to return a list of authors.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/InfoController.java`](diffhunk://#diff-ea0a8bf45c2d6a9bcc88a4c30d5df623f3916a2f9af74def2b60962f3695e751R1-R18): Added `InfoController` with a `/info` endpoint that returns a welcome message.

### Enhancements to Existing Features:

* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java`](diffhunk://#diff-bed6865f4a0cb824d20fcebc0d79e950632b4dec430bac7e7152e3b682630642R29-R39): Added `dateUpdated` field with corresponding getter and setter methods.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java`](diffhunk://#diff-605aff74b9459c7abb6599170c0f9e886806d372d303d57bdb360a6aebab88d8R30-R75): Introduced new endpoints in `PostController` to filter posts by title, first name, and link. Also added a `PUT` endpoint to update posts.

### Tests:

* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/AuthorControllerTest.java`](diffhunk://#diff-5f2a7f6a4894387c89a4b31085305c1585e4733524b1b531ef4fb4c29c5df929R1-R40): Added tests for `AuthorController` to verify the `/authors` endpoint.
* [`src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostTest.java`](diffhunk://#diff-a27bbb517096f1a00a7b46804baa0fefa49362a8d42c5d86e856a201d0a486aeR111-R128): Added tests for the new `dateUpdated` field in the `Post` entity.

### Miscellaneous:

* [`src/functionalTest/java/com/liatrio/dojo/devopsknowledgeshareapi/InfoControllerTest.java`](diffhunk://#diff-19a531d7bfb2670bc5c027296a023e145a23eeb3044aa325705de674e10c313cR1-R49): Commented out the `InfoControllerTest` class.
* [`src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostRepository.java`](diffhunk://#diff-cca0001c4a692ad60f486f2f8554dd59e7e9fb0960a42cc5d0c00918fe6654edR7-R14): Added methods to `PostRepository` to find posts by title, first name, and link.

