### PR TITLE
feat: implement updatePost endpoint and modify datePosted handling

### DIFF
--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/Post.java
@@ -75,7 +75,7 @@ public class Post {
         return "EE MM/dd/yyyy H:m:s:S z";
     }
 
-    public void setDatePosted(Date dateAsDate) {
+    public void setDatePosted(String dateAsDate) {
         DateFormat dateFormat = new SimpleDateFormat(dateFormat());
         this.datePosted = dateFormat.format(dateAsDate);
     }

--- a/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
+++ b/src/main/java/com/liatrio/dojo/devopsknowledgeshareapi/PostController.java
@@ -1,11 +1,16 @@
 package com.liatrio.dojo.devopsknowledgeshareapi;
 
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
 
 import lombok.extern.slf4j.Slf4j;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
+import java.util.Date;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.stream.Collectors;
+import java.util.Optional;
 
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
@@ -35,5 +40,33 @@ public class PostController {
     public void deletePost(@PathVariable("id") String id) {
         log.info("{}: recieved a DELETE request", deploymentType);
         repository.deleteById(Long.parseLong(id));
+    }
+
+    @PutMapping("/posts/{id}")
+    public ResponseEntity<Post> updatePost(@PathVariable("id") Long id, @RequestBody Post postDetails) {
+        log.info("{}: received a PUT request", deploymentType);
+        Optional<Post> optionalPost = repository.findById(id);
+        if (optionalPost.isPresent()) {
+            Post post = optionalPost.get();
+            post.setFirstName(postDetails.getFirstName());
+            post.setTitle(postDetails.getTitle());
+            try {
+                post.setLink(postDetails.getLink());
+            } catch (Exception e) {
+                return ResponseEntity.badRequest().body(null);
+            }
+            try {
+                Date date = new SimpleDateFormat("yyyy-MM-dd").parse(postDetails.getDatePosted());
+                post.setDatePosted(date);
+            } catch (ParseException e) {
+                return ResponseEntity.badRequest().body(null);
+            }
+            post.setImageUrl(postDetails.getImageUrl());
+            post.setDateAsDate(postDetails.getDateAsDate());
+            final Post updatedPost = repository.save(post);
+            return ResponseEntity.ok(updatedPost);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostControllerTest.java
+++ b/src/test/java/com/liatrio/dojo/devopsknowledgeshareapi/PostControllerTest.java
@@ -5,6 +5,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import java.util.Optional;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
@@ -67,5 +72,70 @@ public class PostControllerTest {
                 post("/posts").content(testPost.toString()).with(csrf()).contentType(MediaType.APPLICATION_JSON))
                 .andDo(print()).andExpect(status().isOk());
         this.mockMvc.perform(delete("/posts/1/").with(csrf())).andDo(print()).andExpect(status().isOk());
+    }
+
+    @Test
+    public void updatePostSuccess() throws Exception {
+        Post updatedPost = new Post();
+        updatedPost.setFirstName("Jane");
+        updatedPost.setTitle("Updated Post");
+        updatedPost.setLink("https://www.example.com/blog/updated-post");
+        updatedPost.setDatePosted("2023-10-10");
+        updatedPost.setImageUrl("https://www.example.com/images/updated-post.jpg");
+
+        when(mockPr.findById(1L)).thenReturn(Optional.of(new Post()));
+        when(mockPr.save(any(Post.class))).thenReturn(updatedPost);
+
+        JSONObject updatedPostJson = new JSONObject();
+        updatedPostJson.put("firstName", "Jane");
+        updatedPostJson.put("title", "Updated Post");
+        updatedPostJson.put("link", "https://www.example.com/blog/updated-post");
+        updatedPostJson.put("datePosted", "2023-10-10");
+        updatedPostJson.put("imageUrl", "https://www.example.com/images/updated-post.jpg");
+
+        this.mockMvc.perform(put("/posts/1")
+                .content(updatedPostJson.toString())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void updatePostNotFound() throws Exception {
+        JSONObject updatedPostJson = new JSONObject();
+        updatedPostJson.put("firstName", "Jane");
+        updatedPostJson.put("title", "Updated Post");
+        updatedPostJson.put("link", "https://www.example.com/blog/updated-post");
+        updatedPostJson.put("datePosted", "2023-10-10");
+        updatedPostJson.put("imageUrl", "https://www.example.com/images/updated-post.jpg");
+
+        when(mockPr.findById(1L)).thenReturn(Optional.empty());
+
+        this.mockMvc.perform(put("/posts/1")
+                .content(updatedPostJson.toString())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void updatePostBadRequest() throws Exception {
+        JSONObject updatedPostJson = new JSONObject();
+        updatedPostJson.put("firstName", "Jane");
+        updatedPostJson.put("title", "Updated Post");
+        updatedPostJson.put("link", "https://www.example.com/blog/updated-post");
+        updatedPostJson.put("datePosted", "invalid-date");
+        updatedPostJson.put("imageUrl", "https://www.example.com/images/updated-post.jpg");
+
+        when(mockPr.findById(1L)).thenReturn(Optional.of(new Post()));
+
+        this.mockMvc.perform(put("/posts/1")
+                .content(updatedPostJson.toString())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `PostController` and related files to add support for updating posts via a new PUT endpoint. Additionally, it includes modifications to the `Post` model and updates to the test suite to cover the new functionality.

### Controller changes:
* Added a new PUT endpoint to update posts in `PostController` with validation and error handling for date parsing and missing posts.

### Model changes:
* Changed the `setDatePosted` method in the `Post` model to accept a `String` instead of a `Date` to align with the new update functionality.

### Test changes:
* Added new test cases in `PostControllerTest` to cover successful updates, not found errors, and bad request errors for the new PUT endpoint.
* Imported necessary Mockito and Spring test utilities in `PostControllerTest` to support the new test cases.

